### PR TITLE
feature: add /locations/ endpoint

### DIFF
--- a/explaindev.json
+++ b/explaindev.json
@@ -1,4 +1,1 @@
-{
-  "project": "fleet-management-api",
-  "cohort": "CURR"
-}
+{"project": "fleet-management-api", "cohort": "CURR"}

--- a/fleet_api/app.py
+++ b/fleet_api/app.py
@@ -1,10 +1,13 @@
 from typing import Optional
 from flask import Flask, jsonify, request
 from .config import Config
-from .models.taxis import TaxiModel
+from .models import taxis
+from .models.locations import get_locations
+
 # import pdb
 
 ROWS_PER_PAGE = 20
+
 
 def create_app(cfg: Optional[Config] = None) -> Flask:
     if cfg is None:
@@ -18,9 +21,22 @@ def create_app(cfg: Optional[Config] = None) -> Flask:
         try:
             page = request.args.get("page", 1, type=int)
             per_page = request.args.get("per_page", ROWS_PER_PAGE, type=int)
-            taxis = TaxiModel.get_taxis(page, per_page)
-            response = {"taxis": taxis, "count": len(taxis)}
+            taxis_response = taxis.get(page, per_page)
+            response = {"taxis": taxis_response, "count": len(taxis_response)}
             return jsonify(response)
+        # pylint: disable=broad-except
+        except Exception as ex:
+            # pylint: disable=raise-missing-from
+            return jsonify({"message": str(ex)}), 500
+
+    @app.route("/api/locations/", methods=["GET"])
+    def get_locations_by__taxi_id():
+        try:
+            taxi_id = request.args.get("taxi_id", 1, type=int)
+            page = request.args.get("page", 1, type=int)
+            per_page = request.args.get("per_page", ROWS_PER_PAGE, type=int)
+            locations = get_locations(taxi_id, page, per_page)
+            return jsonify(locations)
         # pylint: disable=broad-except
         except Exception as ex:
             # pylint: disable=raise-missing-from

--- a/fleet_api/config.py
+++ b/fleet_api/config.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 import os
 
+
 # pytest: disable=too-few-public-methods
 class Config:
     DEBUG = True
     DEVELOPMENT = True
-    DB_HOST = os.getenv('POSTGRES_HOST')
+    DB_HOST = os.getenv("POSTGRES_HOST")
     DB_PORT = os.environ.get("DB_PORT", 3306)
-    DB_DATABASE = os.getenv('POSTGRES_DATABASE')
-    DB_USER = os.getenv('POSTGRES_USER')
-    DB_PASSWORD = os.getenv('POSTGRES_PASSWORD')
+    DB_DATABASE = os.getenv("POSTGRES_DATABASE")
+    DB_USER = os.getenv("POSTGRES_USER")
+    DB_PASSWORD = os.getenv("POSTGRES_PASSWORD")

--- a/fleet_api/database/db.py
+++ b/fleet_api/database/db.py
@@ -1,12 +1,14 @@
 import os
 from psycopg2 import DatabaseError, connect
 
+
 def get_connection():
     try:
         return connect(
-          host=os.getenv('POSTGRES_HOST'),
-          user=os.getenv('POSTGRES_USER'),
-          password=os.getenv('POSTGRES_PASSWORD'),
-          database=os.getenv('POSTGRES_DATABASE'))
+            host=os.getenv("POSTGRES_HOST"),
+            user=os.getenv("POSTGRES_USER"),
+            password=os.getenv("POSTGRES_PASSWORD"),
+            database=os.getenv("POSTGRES_DATABASE"),
+        )
     except DatabaseError as ex:
         raise ex

--- a/fleet_api/models/locations.py
+++ b/fleet_api/models/locations.py
@@ -1,0 +1,33 @@
+from ..database.db import get_connection
+
+ROWS_PER_PAGE = 10
+
+
+def get_locations(taxi_id, page, per_page):
+    offset = (page - 1) * per_page
+    try:
+        connection = get_connection()
+        locations = []
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """SELECT * FROM trajectories WHERE Taxi_id='%s' LIMIT %s OFFSET %s""",
+                (taxi_id, per_page, offset),
+            )
+            resultset = cursor.fetchall()
+
+            locations = [
+                {
+                    "id": row[0],
+                    "plate": row[1],
+                    "timestamp": row[2].timestamp(),
+                    "lat": row[3],
+                    "lon": row[4],
+                }
+                for row in resultset
+            ]
+
+        connection.close()
+        return locations
+    except Exception as ex:
+        # pylint: disable=raise-missing-from,broad-exception-raised
+        raise Exception(ex)

--- a/fleet_api/models/taxis.py
+++ b/fleet_api/models/taxis.py
@@ -3,23 +3,25 @@ from ..database.db import get_connection
 
 # https://pylint.readthedocs.io/en/stable/user_guide/messages/refactor/too-few-public-methods.html
 
-class TaxiModel():
-    @classmethod
-    def get_taxis(cls, page=1, per_page=10):
-        offset = (page - 1) * per_page
 
-        try:
-            connection = get_connection()
-            taxis = []
-            with connection.cursor() as cursor:
-                cursor.execute("""SELECT * from TAXIS
-                                LIMIT %s OFFSET %s""", (per_page, offset))
-                resultset = cursor.fetchall()
+def get(page=1, per_page=10):
+    offset = (page - 1) * per_page
 
-                taxis = [{'id': row[0], 'plate': row[1]} for row in resultset]
+    try:
+        connection = get_connection()
+        taxis = []
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """SELECT * from TAXIS
+                            LIMIT %s OFFSET %s""",
+                (per_page, offset),
+            )
+            resultset = cursor.fetchall()
 
-            connection.close()
-            return taxis
-        except Exception as ex:
-             # pylint: disable=raise-missing-from,broad-exception-raised
-            raise Exception(ex)
+            taxis = [{"id": row[0], "plate": row[1]} for row in resultset]
+
+        connection.close()
+        return taxis
+    except Exception as ex:
+        # pylint: disable=raise-missing-from,broad-exception-raised
+        raise Exception(ex)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,3 @@
 [pytest]
 log_cli = True
 log_cli_level = INFO
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,11 @@
 import pytest
+
 # import logging
-from fleet_api.models.taxis import TaxiModel
 from fleet_api.app import create_app
+from fleet_api.models import taxis
 
 MOCKED_RESPONSE = [
-    {
-        "id": "7249",
-        "plate": "CNCJ-2997"
-    },
+    {"id": "7249", "plate": "CNCJ-2997"},
     {
         "id": "10133",
         "plate": "PAOF-6727",
@@ -15,6 +13,30 @@ MOCKED_RESPONSE = [
     {
         "id": "2210",
         "plate": "FGMG-3071",
+    },
+]
+
+MOCK_LOCATIONS = [
+    {
+        "id": 6418,
+        "plate": "GHGH-1458",
+        "timestamp": 1202435486,
+        "lat": 116.30509,
+        "lon": 39.96563,
+    },
+    {
+        "id": 6419,
+        "plate": "GHGH-1458",
+        "timestamp": 1202435486,
+        "lat": 116.30509,
+        "lon": 39.96563,
+    },
+    {
+        "id": 6420,
+        "plate": "GHGH-1458",
+        "timestamp": 1202435486,
+        "lat": 116.30509,
+        "lon": 39.96563,
     },
 ]
 
@@ -31,30 +53,15 @@ def app():
 
 @pytest.fixture
 def client(app):
-     # pylint: disable=redefined-outer-name
+    # pylint: disable=redefined-outer-name
     client = app.test_client()
     yield client
 
-# pytest: disable=too-few-public-methods
-class TaxiModelMock:
-    # mock json() method always returns a specific testing dictionary
-    @staticmethod
-    def get_taxis():
-        return MOCKED_RESPONSE
-
-# pytest: disable=too-few-public-methods
-class MockResponse:
-    @staticmethod
-    def json():
-        return {"mock_key": "mock_response"}
+# pylint: disable=unused-argument
+def get_mock(page=1, per_page=10):
+    return MOCKED_RESPONSE
 
 
 @pytest.fixture
 def mock_response(monkeypatch):
-    """Requests.get() mocked to return {'mock_key':'mock_response'}."""
-
-    # pylint: disable=unused-argument
-    def mock_get(*args, **kwargs):
-        return TaxiModelMock().get_taxis()
-
-    monkeypatch.setattr(TaxiModel, "get_taxis", mock_get)
+    monkeypatch.setattr(taxis, "get", get_mock)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3,7 +3,12 @@ from .conftest import MOCKED_RESPONSE
 
 # pylint: disable=unused-argument
 def test_get_taxis(client, mock_response):
-    response = client.get('/api/taxis/')
+    response = client.get("/api/taxis/")
     response_data = json.loads(response.get_data(as_text=True))
-    assert response_data['count'] == 3
-    assert response_data['taxis'] == MOCKED_RESPONSE
+    assert response_data["count"] == 3
+    assert response_data["taxis"] == MOCKED_RESPONSE
+
+# # pylint: disable=unused-argument
+# def get_locations_by__taxi_id(client, mock_response):
+#     response = client.get("/api/locations/?taxi_id=6419")
+#     response_data = json.loads(response.get_data(as_text=True))


### PR DESCRIPTION
## Includes

- [x]  `/api/locations/ ` endpoint working. A `taxi_id` needs to be passed in order the fetch all its location history
- [ ] Tests
- [ ] Swagger Docs

Quick note: I just noticed that we're adding some tests in another PR so we can avoid merge conflicts. We can discuss this

This closes #3 